### PR TITLE
@action/first-interaction removed.

### DIFF
--- a/.github/workflows/build-validate-api.yml
+++ b/.github/workflows/build-validate-api.yml
@@ -29,12 +29,12 @@ jobs:
     name: Build ${{ inputs.apiName }}
     runs-on: ubuntu-latest
     steps:
-      - name: First Interaction
-        uses: actions/first-interaction@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: 'This is your first submitted issue, THANK YOU! Someone will review shortly.'
-          pr-message: 'This is your your first PR, THANK YOU! Someone will review shortly.'
+      # - name: First Interaction
+      #   uses: actions/first-interaction@v1
+      #   with:
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     issue-message: 'This is your first submitted issue, THANK YOU! Someone will review shortly.'
+      #     pr-message: 'This is your your first PR, THANK YOU! Someone will review shortly.'
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
action `build-validate-api.yml` updated
remove gh action `@action/first-interaction` as it is in error due to ESM.
It appears that the `first-interaction` [repo](https://github.com/actions/first-interaction) didn't commit their json-lock file and is pulling in latest of `@octcat/graphql` which is now a ESM package (or something like that). 

