### PR TITLE
fix: ensures google run traffic 100% to latest revision

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -97,6 +97,7 @@ jobs:
           SENTRYREL=SENTRY_VERSION=that-api-${{ inputs.apiName }}@$(cat __build__/package.json | jq '.version' | tr -d '"')-$C_CNT.$(echo $GITHUB_SHA | cut -c1-7)
           GCR_ENV_VARS="${GCR_ENV_VARS}, ${SENTRYREL}"
           gcloud run deploy ${{ inputs.apiName }} --image us.gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ inputs.apiName }} --region=us-central1 --platform=managed --allow-unauthenticated --set-env-vars="$GCR_ENV_VARS" --timeout=${{ inputs.runTimeout }} --memory=${{ inputs.runMemory }} --cpu=1 --min-instances=${{ inputs.minInstances }}
+          gcloud run services update-traffic ${{ inputs.apiName }} --to-latest --region=us-central1
         env:
           CLOUDSDK_CORE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
       - name: Slack Failure Notification

--- a/.github/workflows/redeploy-gateway.yml
+++ b/.github/workflows/redeploy-gateway.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}          
       - name: Setup gcloud CLI action
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: '428.0.0'
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
This adds `gcloud` command: 
```gcloud run services update-traffic <service> --to-latest```

which sets Google Run traffic management to us the latest (stable) version. If by chance Run was using a different version or wasn't set to latest due to switching versions around. After deploy latest version will again be routed to.
